### PR TITLE
New post-processing functionality, fields, prefixing

### DIFF
--- a/data/filters/agg_postprocess.py
+++ b/data/filters/agg_postprocess.py
@@ -1,0 +1,65 @@
+def cmp_binning(left, right, zero_label, left_label, right_label):
+    if not left:
+        res = zero_label
+    elif left < right:
+        res = '2. {} < {}'.format(left_label, right_label)
+    elif left < 2 * right:
+        res = '3. {} < 2 * {}'.format(left_label, right_label)
+    elif left < 5 * right:
+        res = '4. {} < 5 * {}'.format(left_label, right_label)
+    else:
+        res = '5. {} >= 5 * {}'.format(left_label, right_label)
+    return res
+
+
+def percentage_binning(v, zero_label):
+    if not v:
+        res = zero_label
+    elif v < 0.25:
+        res = '2. До 25%'
+    elif v < 0.75:
+        res = '3. Від 25% до 75%'
+    else:
+        res = '4. Від 75%'
+    return res
+
+
+def postprocess_func(df):
+    df['assets_incomes_ratio'] = df.apply(
+        lambda r: cmp_binning(
+            r['assets.total'], r['incomes.total'],
+            zero_label='1. Немає активів взагалі',
+            left_label='Активи',
+            right_label='річний дохід'
+        ), axis=1
+    )
+    df['liabilities_assets_and_incomes_ratio'] = df.apply(
+        lambda r: cmp_binning(
+            r['liabilities.total'], r['assets.total'] + r['incomes.total'],
+            zero_label='1. Немає зобов’язань взагалі',
+            left_label='Зобов’язання',
+            right_label='(активи + річний дохід)'
+        ), axis=1
+    )
+    df['expenses_assets_and_incomes_ratio'] = df.apply(
+        lambda r: cmp_binning(
+            r['expenses.total'], r['assets.total'] + r['incomes.total'],
+            zero_label='1. Немає видатків взагалі',
+            left_label='Видатки',
+            right_label='(активи + річний дохід)'
+        ), axis=1
+    )
+
+    df['assets.family_ratio_cat'] = df['assets.family_ratio'].apply(
+        lambda v: percentage_binning(v, zero_label='1. Немає активів взагалі')
+    )
+    df['incomes.family_ratio_cat'] = df['incomes.family_ratio'].apply(
+        lambda v: percentage_binning(v, zero_label='1. Немає доходів взагалі')
+    )
+    df['estate.family_land_ratio_cat'] = df['estate.family_land_ratio'].apply(
+        lambda v: percentage_binning(v, zero_label='1. Немає землі взагалі')
+    )
+    df['estate.family_other_ratio_cat'] = df['estate.family_other_ratio'].apply(
+        lambda v: percentage_binning(v, zero_label='1. Немає нерухомості взагалі')
+    )
+    return df

--- a/data/filters/outlier_agg_filter.py
+++ b/data/filters/outlier_agg_filter.py
@@ -1,4 +1,6 @@
-def filter_func(df):
+def postprocess_func(df):
+    df['outlier'] = False
+
     q1 = ((df['incomes.total'] > 100000000) | (df['estate.total_other'] > 5000))\
         & (df['name_post'].str.contains('депутат', case=False))
     q2 = (df['estate.total_land'] > 20000000)
@@ -9,4 +11,6 @@ def filter_func(df):
         'nacp_08a63d8b-2db4-4ef0-8b8b-396e0cd9f495',
         'nacp_7762d918-fe93-4285-8703-7fbe18312634',
         'nacp_50a32d11-ebfa-4466-9bde-2f049cb00574']))
-    return (q1 | q2 | q3 | q4 | q5) & excl
+    df.loc[(q1 | q2 | q3 | q4 | q5) & excl, 'outlier'] = True
+
+    return df

--- a/data/profiles/aggregated.json
+++ b/data/profiles/aggregated.json
@@ -42,7 +42,7 @@
                 "columns": [
                     "id", "estate.declarant_land", "estate.declarant_other", "estate.family_land",
                     "estate.family_other", "estate.total_land", "estate.total_other", "estate.has_hidden",
-                    "estate.has_foreign"
+                    "estate.has_foreign", "estate.family_land_ratio", "estate.family_other_ratio"
                 ]
             },
             {
@@ -58,7 +58,7 @@
                 "output": "{datadir}/export/step_11_incomes_agg.csv",
                 "columns": [
                     "id", "incomes.declarant", "incomes.family", "incomes.total", "incomes.has_hidden",
-                    "incomes.has_foreign"
+                    "incomes.has_foreign", "incomes.family_ratio"
                 ]
             },
             {
@@ -66,7 +66,7 @@
                 "output": "{datadir}/export/step_12_assets_agg.csv",
                 "columns": [
                     "id", "assets.declarant", "assets.family", "assets.total", "assets.has_hidden",
-                    "assets.has_foreign"
+                    "assets.has_foreign", "assets.family_ratio"
                 ]
             },
             {
@@ -112,7 +112,7 @@
             "{datadir}/export/step_6_vehicles_agg.csv", "{datadir}/export/step_11_incomes_agg.csv",
             "{datadir}/export/step_12_assets_agg.csv"
         ],
-        "outlier_filters": "{datadir}/filters/outlier_agg_filter.py",
+        "postprocess": ["{datadir}/filters/outlier_agg_filter.py", "{datadir}/filters/agg_postprocess.py"],
         "only_years": []
     },
     "pump": {

--- a/utils/merge.py
+++ b/utils/merge.py
@@ -5,7 +5,7 @@ import pandas
 logger = logging.getLogger('dragnet.merge')
 
 
-def merge_csv(filename, inputs, on_field, nan_replacements=None, outlier_filters=None, only_years=None):
+def merge_csv(filename, inputs, on_field, nan_replacements=None, postprocess_funcs=None, only_years=None):
     logger.info('Merging files: {}'.format(inputs))
 
     df = pandas.read_csv(inputs[0])
@@ -28,11 +28,12 @@ def merge_csv(filename, inputs, on_field, nan_replacements=None, outlier_filters
                 col_replacement = nan_replacements['types'].get(dtype.name, None)
             df[column].fillna(col_replacement, inplace=True)
 
-    if outlier_filters:
-        logger.info('Adding outliers')
-        df['outlier'] = False
-        df.loc[outlier_filters(df), 'outlier'] = True
+    if postprocess_funcs:
+        for pp_func in postprocess_funcs:
+            logger.info('Applying post-processing function')
+            df = pp_func(df)
 
+    logger.info('Exporting to CSV')
     df.to_csv(filename, index=False, na_rep='null')
     logger.info('Merged output wrote to file "{}"'.format(filename))
 

--- a/views/aggregated/step_11_incomes.es6
+++ b/views/aggregated/step_11_incomes.es6
@@ -14,9 +14,9 @@
             continue;
         if (income_doc.sizeIncome === undefined)
             continue;
-        if (income_doc.is_foreign == true)
+        if (income_doc.dnt_is_foreign == true)
             has_foreign = true;
-        if (income_doc.sizeIncome_hidden) {
+        if (income_doc.dnt_sizeIncome_hidden) {
             has_hidden = true;
             continue;
         }
@@ -28,5 +28,9 @@
         total_income += income_doc.sizeIncome;
     }
 
-    emit(doc._id, [doc.doc_uuid, declarant_income, family_income, total_income, has_hidden, has_foreign]);
+    let family_ratio = 0.0;
+    if (total_income != 0.0)
+        family_ratio = family_income / total_income;
+
+    emit(doc._id, [doc.doc_uuid, declarant_income, family_income, total_income, has_hidden, has_foreign, family_ratio]);
 }

--- a/views/aggregated/step_12_assets.es6
+++ b/views/aggregated/step_12_assets.es6
@@ -139,9 +139,9 @@
         // Sometimes there's just broken JSON
         if (assets_doc.sizeAssets === undefined)
             continue;
-        if (assets_doc.is_foreign == true)
+        if (assets_doc.dnt_is_foreign == true)
             has_foreign = true;
-        if (assets_doc.sizeAssets_hidden) {
+        if (assets_doc.dnt_sizeAssets_hidden) {
             has_hidden = true;
             continue;
         }
@@ -165,5 +165,9 @@
         total_assets += val;
     }
 
-    emit(doc._id, [doc.doc_uuid, declarant_assets, family_assets, total_assets, has_hidden, has_foreign]);
+    let family_ratio = 0.0;
+    if (total_assets != 0.0)
+        family_ratio = family_assets / total_assets;
+
+    emit(doc._id, [doc.doc_uuid, declarant_assets, family_assets, total_assets, has_hidden, has_foreign, family_ratio]);
 }

--- a/views/aggregated/step_3_estate.es6
+++ b/views/aggregated/step_3_estate.es6
@@ -21,20 +21,20 @@
             continue;
         if (estate_doc.country != '1')
             has_foreign = true;
-        if (estate_doc.totalArea_hidden) {
+        if (estate_doc.dnt_totalArea_hidden) {
             has_hidden = true;
             continue;
         }
 
-        const estate_key = `${estate_doc.ua_cityType}.${estate_doc.totalArea}.${estate_doc.objectType_encoded}`;
+        const estate_key = `${estate_doc.ua_cityType}.${estate_doc.totalArea}.${estate_doc.dnt_objectType_encoded}`;
         if (estate_doc.person == '1') {
-            if (estate_doc.objectType_encoded == 'land')
+            if (estate_doc.dnt_objectType_encoded == 'land')
                 declarant_land += estate_doc.totalArea;
             else
                 declarant_other += estate_doc.totalArea;
         } else if (String(estate_doc.person) in (nacp_doc.step_2 || {})) {
             if (!seen_family_estates.has(estate_key)) {
-                if (estate_doc.objectType_encoded == 'land')
+                if (estate_doc.dnt_objectType_encoded == 'land')
                     family_land += estate_doc.totalArea;
                 else
                     family_other += estate_doc.totalArea;
@@ -43,7 +43,7 @@
         }
 
         if (!seen_all_estates.has(estate_key)) {
-            if (estate_doc.objectType_encoded == 'land')
+            if (estate_doc.dnt_objectType_encoded == 'land')
                 total_land += estate_doc.totalArea;
             else
                 total_other += estate_doc.totalArea;
@@ -51,6 +51,14 @@
         }
     }
 
+    let family_land_ratio = 0.0;
+    if (total_land != 0.0)
+        family_land_ratio = family_land / total_land;
+
+    let family_other_ratio = 0.0;
+    if (total_other != 0.0)
+        family_other_ratio = family_other / total_other;
+
     emit(doc._id, [doc.doc_uuid, declarant_land, declarant_other, family_land, family_other, total_land, total_other, has_hidden,
-                   has_foreign]);
+                   has_foreign, family_land_ratio, family_other_ratio]);
 }

--- a/views/meta.es6
+++ b/views/meta.es6
@@ -13,5 +13,5 @@
         mapped_region = 'Кримська Автономна Республіка';
     emit(doc._id,
          [doc.doc_uuid, dcu_link, full_name, nacp_doc.step_0.declarationYear1, name_post,
-          has_family, nacp_doc.step_1.organization_group, mapped_region]);
+          has_family, nacp_doc.step_1.dnt_organization_group, mapped_region]);
 }

--- a/views/red_flags.es6
+++ b/views/red_flags.es6
@@ -185,7 +185,7 @@
             const right = subdoc.rights[right_key];
             if (!right)
                 continue;
-            if (ownership_types.indexOf(right.ownershipType_encoded) != -1) {
+            if (ownership_types.indexOf(right.dnt_ownershipType_encoded) != -1) {
                 return true;
             }
         }
@@ -213,7 +213,7 @@
             if (!isOwned(estate_doc))
                 continue;
 
-            switch (estate_doc.objectType_encoded) {
+            switch (estate_doc.dnt_objectType_encoded) {
                 case 'garage':
                     has_garage = true;
                     break;
@@ -270,7 +270,7 @@
                 continue;
             if (income_doc.sizeIncome === undefined)
                 continue;
-            if (present_types.indexOf(income_doc.objectType_encoded) != -1)
+            if (present_types.indexOf(income_doc.dnt_objectType_encoded) != -1)
                 total_presents += income_doc.sizeIncome;
             total_income += income_doc.sizeIncome;
         }
@@ -287,7 +287,7 @@
             if (val == null)
                 continue;
 
-            if (assets_doc.objectType_encoded == 'cash')
+            if (assets_doc.dnt_objectType_encoded == 'cash')
                 total_cash += val;
             total_assets += val;
         }
@@ -313,6 +313,8 @@
             if (typeof(expense_doc) != 'object')
                 continue;
             if (expense_doc.costAmount === undefined)
+                continue;
+            if (expense_doc.type != 1)
                 continue;
             total_expenses += expense_doc.costAmount;
         }


### PR DESCRIPTION
This adds a new post-processing for the merger step, which applies arbitrary functions (defined in the profile) to the merged Pandas dataframe. Outlier filters have been transformed into a post-processing function and ability to define multiple functions added. There's also a new post-processing function to work on merged aggregates.

There are now several new fields with calculated ratios. Fields that are added to the document during the pre-processing phase of import are now prefixed with "dnt_" string.

In addition to this, expenses total of the red flags view should be more accurate now by taking type into account.